### PR TITLE
Fix compiler warnings

### DIFF
--- a/simplewebp.h
+++ b/simplewebp.h
@@ -5121,7 +5121,7 @@ static simplewebp_error swebp__decode_lossless_bitstream_main(
 	struct swebp__pixel *filter_data[4];
 	simplewebp_u8 filter_bits[4];
 	simplewebp_bool filter_active[4];
-	int i;
+	size_t i;
 	simplewebp_error err;
 
 	simplewebp_get_dimensions(simplewebp, &actual_width, &actual_height);
@@ -5232,34 +5232,36 @@ static simplewebp_error swebp__decode_lossless_bitstream_main(
 	}
 
 	/* Apply transform */
-	i--;
-	for (; i >= 0; i--)
 	{
-		simplewebp_u8 ttype;
-		ttype = filter_list & 3;
-
-		switch (ttype)
+		int j = (int)(i - 1);
+		for (; j >= 0; j--)
 		{
-			case 0:
-				/* Predictor Transform */
-				swebp__apply_predictor_transform(rgba, width, height, filter_bits[i], filter_data[i]);
-				break;
-			case 1:
-				/* Color Transform */
-				swebp__apply_color_transform(rgba, width, height, filter_bits[i], filter_data[i]);
-				break;
-			case 2:
-				/* Green Transform */
-				swebp__apply_green_sub_transform(rgba, width, height);
-				break;
-			case 3:
-				/* Color Index Transform */
-				width = (simplewebp_u32) full_width;
-				swebp__apply_index_transform(rgba, width, height, filter_bits[i], filter_data[i]);
-				break;
-		}
+			simplewebp_u8 ttype;
+			ttype = filter_list & 3;
 
-		filter_list >>= 2;
+			switch (ttype)
+			{
+				case 0:
+					/* Predictor Transform */
+					swebp__apply_predictor_transform(rgba, width, height, filter_bits[j], filter_data[j]);
+					break;
+				case 1:
+					/* Color Transform */
+					swebp__apply_color_transform(rgba, width, height, filter_bits[j], filter_data[j]);
+					break;
+				case 2:
+					/* Green Transform */
+					swebp__apply_green_sub_transform(rgba, width, height);
+					break;
+				case 3:
+					/* Color Index Transform */
+					width = (simplewebp_u32) full_width;
+					swebp__apply_index_transform(rgba, width, height, filter_bits[j], filter_data[j]);
+					break;
+			}
+
+			filter_list >>= 2;
+		}
 	}
 
 	swebp__batch_free(simplewebp, (void **) filter_data, sizeof(simplewebp_u8) * 4);

--- a/simplewebp.h
+++ b/simplewebp.h
@@ -477,11 +477,13 @@ struct simplewebp_memoryinput_data
 
 static void *swebp__malloc(void *_unused, size_t size)
 {
+	(void)_unused;
 	return malloc(size);
 }
 
 static void swebp__free(void *_unused, void *mem)
 {
+	(void)_unused;
 	free(mem);
 }
 
@@ -4206,6 +4208,7 @@ static simplewebp_error swebp__vp8_parse_frame(struct swebp__vp8 *vp8d, struct s
 
 static simplewebp_error swebp__decode_lossy(simplewebp *simplewebp, struct swebp__yuvdst *destination, void *settings)
 {
+	(void)settings;
 	simplewebp_input input;
 	size_t vp8size;
 	simplewebp_u8 *vp8buffer, *decoder_mem;
@@ -4854,6 +4857,8 @@ static simplewebp_error swebp__decode_color_index_transform(
 	struct swebp__pixel **dest
 )
 {
+	(void)width;
+	(void)height;
 	simplewebp_u32 color_count, i;
 	simplewebp_error err;
 	struct swebp__pixel *pixel_data;

--- a/simplewebp.h
+++ b/simplewebp.h
@@ -4748,7 +4748,7 @@ static simplewebp_error swebp__decode_vp8l_image(
 
 			if (codeword < swebp__vp8l_literals_count)
 			{
-				struct swebp__pixel color = {0};
+				struct swebp__pixel color = {0, 0, 0, 0};
 				color.r = (simplewebp_u8) swebp__vp8l_read_code(br, &g->code[1]);
 				color.g = (simplewebp_u8) codeword;
 				color.b = (simplewebp_u8) swebp__vp8l_read_code(br, &g->code[2]);
@@ -5087,7 +5087,7 @@ static void swebp__apply_index_transform(
 	simplewebp_u32 color_count;
 	simplewebp_u8 bits, mask, mod, rb;
 	size_t stride;
-	const struct swebp__pixel transparent_black = {0};
+	const struct swebp__pixel transparent_black = {0, 0, 0, 0};
 
 	color_count = ((simplewebp_u32) size) + 1;
 	bits = swebp__vp8l_index_reduction(color_count);

--- a/simplewebp.h
+++ b/simplewebp.h
@@ -902,6 +902,7 @@ static void swebp__alpha_apply_filters(simplewebp_u8 *ptr, size_t width, size_t 
 				default:
 					/* Should not happen */
 					predictor = 0;
+					/* FALLTHROUGH */
 				case 1:
 					predictor = x == 0 ? ptr[i - width] : ptr[i - 1];
 					break;
@@ -5498,7 +5499,7 @@ simplewebp_error simplewebp_load_from_filename(const char *filename, const simpl
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  *    products derived from this software without specific prior written permission.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR

--- a/simplewebp.h
+++ b/simplewebp.h
@@ -1143,7 +1143,7 @@ simplewebp_error simplewebp_load(simplewebp_input *input, const simplewebp_alloc
 			/* Input unused. */
 			simplewebp_close_input(&chunk_input_proxy);
 
-		if (!swebp__seek(current_position + (chunk_size + 1) & (~((size_t) 1)), &result->riff_input))
+		if (!swebp__seek(current_position + ((chunk_size + 1) & (~((size_t) 1))), &result->riff_input))
 		{
 			err = SIMPLEWEBP_IO_ERROR;
 			break;


### PR DESCRIPTION
## Fix
 -  (4dc9fd0dc8c784aca3e0fd86226ece28f58883d3) add fallthrough comment and normalize license quotes
 - (f99faa6819a44ca4124dd7b2b3954bde593e6847) correct operator precedence in RIFF chunk seek offset
 - (ae10e3a56a7a2c60dcf16541389503e64b69033c) prevent integer underflow in transform application loop
 - (1a0db2a0d04bb2bfebe44101983e7c049b255e24) explicity zero-initialize all swebp__pixel struct members
 - (f2574f4ca47a2ed949a423790cd25b1a92a8e39a) suppress unused parameter compiler warnings